### PR TITLE
#72 API 호출 시 HTTP 응답 상태 코드가 400, 404 일 때 공통 오류 처리 지원

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ build
 .DS_Store
 .env
 npm-debug.log
-
+package-lock.json
 yarn-error.log
 yarn.lock
 .idea/

--- a/src/config/admin.config.js
+++ b/src/config/admin.config.js
@@ -13,6 +13,8 @@ const BetterAdminConfig = {
   },
   errorMessage: {
     serverInternalError: '오류가 발생 했습니다. 잠시 후 다시 시도해 주세요.',
+    badRequestError: '잘못된 요청입니다.',
+    pageNotFoundError: '페이지를 찾을 수 없습니다.',
     networkError: '네트워크 연결이 원활하지 않습니다. 다시 한번 시도해 주세요.',
     badAccessPathError: '잘못된 경로 입니다. 메뉴를 통해 접근해 주세요.'
   }

--- a/src/config/axios.configur.js
+++ b/src/config/axios.configur.js
@@ -69,15 +69,21 @@ export class AxiosConfigur {
 
   }
 
-  static configServerInternalErrorInterceptor() {
+  static configServerErrorInterceptor() {
     // Add a response interceptor
     axios.interceptors.response.use(function (response) {
       // Any status code that lie within the range of 2xx cause this function to trigger
       return response;
     }, function (error) {
       // Any status codes that falls outside the range of 2xx cause this function to trigger
-      if (error.response && error.response.status && error.response.status === 500) {
-        EventBroadcaster.broadcast(SHOW_ERROR_MESSAGE_EVENT_TOPIC, adminConfig.errorMessage.serverInternalError);
+      if (error.response && error.response.status) {
+        if (error.response.status === 500) {
+          EventBroadcaster.broadcast(SHOW_ERROR_MESSAGE_EVENT_TOPIC, adminConfig.errorMessage.serverInternalError);
+        } else if(error.response.status === 400) {
+          EventBroadcaster.broadcast(SHOW_ERROR_MESSAGE_EVENT_TOPIC, adminConfig.errorMessage.badRequestError);
+        } else if(error.response.status === 404) {
+          EventBroadcaster.broadcast(SHOW_ERROR_MESSAGE_EVENT_TOPIC, adminConfig.errorMessage.pageNotFoundError);
+        }
       }
       return Promise.reject(error);
     });

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ if (adminConfig.authentication.used) {
 }
 
 AxiosConfigur.configServerNetworkErrorInterceptor();
-AxiosConfigur.configServerInternalErrorInterceptor();
+AxiosConfigur.configServerErrorInterceptor();
 AxiosConfigur.configLoadingInterceptor();
 
 ReactDOM.render(


### PR DESCRIPTION
아래와 같이 공통 오류 메시지가 나오도록 처리하고
오류 메시지를 설정할 수 있도록 반영

![image](https://user-images.githubusercontent.com/16472109/137879980-bf45a041-e355-4683-ba25-9db9649d0e5d.png)

![image](https://user-images.githubusercontent.com/16472109/137880004-c5147084-4d16-4d2c-9d92-2c252fe4cbb9.png)
