### PR TITLE
#216 '두레이 로그인' 화면에 사용한 Ant Design Components 를 Better Admin Design Components로 정의하고 대체한다

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import {
   SHOW_WEB_HOOK_MESSAGE_EVENT_TOPIC
 } from "./event/event.broadcaster";
 import {ExclamationCircleOutlined, NotificationTwoTone} from "@ant-design/icons";
-import OAuthLoginResult from "./components/login/OAuthLoginResult";
+import OAuthLoginResult from "./components/templates/login/OAuthLoginResult";
 import ProtectedRoute from "./components/router/ProtectedRoute";
 import {AuthService} from "./auth/auth.service";
 import Login from "./components/templates/login/Login";

--- a/src/components/atoms/modal/index.js
+++ b/src/components/atoms/modal/index.js
@@ -1,9 +1,10 @@
 import React from "react";
-import { Modal as AntModal } from 'antd';
+import {Modal as AntModal} from 'antd';
 import PropTypes from "prop-types";
 
-export const Modal = ({title, open, width, footer, onCancel, onAfterClose, children}) => {
-  return <AntModal title={title} open={open} onCancel={onCancel} footer={footer} width={width} afterClose={onAfterClose}>
+export const Modal = ({title, open, width, okText, cancelText, onOk, onCancel, onAfterClose, children}) => {
+  return <AntModal title={title} open={open} okText={okText} cancelText={cancelText}
+                   onOk={onOk} onCancel={onCancel} width={width} afterClose={onAfterClose}>
     {children}
   </AntModal>
 };
@@ -12,7 +13,9 @@ Modal.propTypes = {
   title: PropTypes.string,
   open: PropTypes.bool,
   width: PropTypes.number,
-  footer: PropTypes.any,
+  okText: PropTypes.string,
+  cancelText: PropTypes.string,
+  onOk: PropTypes.func,
   onCancel: PropTypes.func,
   onAfterClose: PropTypes.func,
   children: PropTypes.any
@@ -20,10 +23,27 @@ Modal.propTypes = {
 
 Modal.defaultProps = {
   open: false,
-  width: 520
+  width: 520,
+  okText: "예",
+  cancelText: "아니오"
 };
 
+export const SimpleModal = ({title, open, width, onCancel, onAfterClose, children}) => {
+  return <AntModal title={title} open={open} onCancel={onCancel} footer={null} width={width} afterClose={onAfterClose}>
+    {children}
+  </AntModal>
+};
 
+SimpleModal.propTypes = {
+  title: PropTypes.string,
+  open: PropTypes.bool,
+  width: PropTypes.number,
+  onCancel: PropTypes.func,
+  onAfterClose: PropTypes.func,
+  children: PropTypes.any
+};
 
-
-
+SimpleModal.defaultProps = {
+  open: false,
+  width: 520
+};

--- a/src/components/atoms/modal/index.stories.js
+++ b/src/components/atoms/modal/index.stories.js
@@ -1,36 +1,24 @@
 import React from 'react';
-import {Modal} from "./index";
-import {Form} from "../form";
-import {TextInput} from "../text-input";
-import {UserOutlined} from "@ant-design/icons";
-import {FormItem} from "../form/form-item";
-import {Button} from "../button";
+import {Modal, SimpleModal} from "./index";
 
 export default {
   title: 'atoms/Modal',
 };
 
-const Template = (args) => <Modal {...args} />;
+const SimpleModalTemplate = (args) => <SimpleModal {...args} />;
 
-export const FooterNotUsed = Template.bind({});
-FooterNotUsed.args = {
-  title: '기본 Footer를 사용하지 않고 Modal 에 Form 사용 예시',
+export const Simple = SimpleModalTemplate.bind({});
+Simple.args = {
+  title: '간단한 Modal',
   open: true,
-  footer: null,
-  children: <Form onFinish={(values) => {window.alert("입력 값" + values.id)}}>
-    <FormItem
-      name="id"
-      rules={[
-        {
-          required: true,
-          message: '아이디를 입력해 주세요.',
-        },
-      ]}
-    >
-      <TextInput prefix={<UserOutlined/>} placeholder="아이디"/>
-    </FormItem>
-    <FormItem>
-      <Button label="신청" type="primary" htmlType="submit"/>
-    </FormItem>
-  </Form>
+  children: <><p>내용들...</p><p>내용들....</p></>
+};
+
+const BasicModalTemplate = (args) => <Modal {...args} />;
+
+export const Basic = BasicModalTemplate.bind({});
+Basic.args = {
+  title: '기본 Modal',
+  open: true,
+  children: <><p>내용들...</p><p>내용들....</p></>
 };

--- a/src/components/templates/access-control/permission/PermissionForm.js
+++ b/src/components/templates/access-control/permission/PermissionForm.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from "react";
 import {Button, Form, Input, message, PageHeader} from 'antd';
-import {AccessControlService} from "../../../services/access.control.service";
+import {AccessControlService} from "../../../../services/access.control.service";
 import {EventBroadcaster, SHOW_ERROR_MESSAGE_EVENT_TOPIC} from "../../../../event/event.broadcaster";
 import {adminConfig} from "../../../../config/admin.config";
 import {useNavigate, useParams, useSearchParams} from "react-router-dom";

--- a/src/components/templates/access-control/permission/PermissionList.js
+++ b/src/components/templates/access-control/permission/PermissionList.js
@@ -8,7 +8,7 @@ import {
   PlusCircleOutlined,
   SettingOutlined
 } from '@ant-design/icons';
-import {AccessControlService} from "../../../services/access.control.service";
+import {AccessControlService} from "../../../../services/access.control.service";
 import {Link, useLocation, useNavigate, useSearchParams} from "react-router-dom";
 import {SearchForm, SearchResult} from "../../../modules/search-form";
 

--- a/src/components/templates/access-control/role/RoleForm.js
+++ b/src/components/templates/access-control/role/RoleForm.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from "react";
 import {Button, Form, Input, message, PageHeader, Select} from 'antd';
-import {AccessControlService} from "../../../services/access.control.service";
+import {AccessControlService} from "../../../../services/access.control.service";
 import {EventBroadcaster, SHOW_ERROR_MESSAGE_EVENT_TOPIC} from "../../../../event/event.broadcaster";
 import {adminConfig} from "../../../../config/admin.config";
 import {FormItemLayout, FormTailItemLayout} from "../../../modules/layout/from-item";

--- a/src/components/templates/access-control/role/RoleList.js
+++ b/src/components/templates/access-control/role/RoleList.js
@@ -8,7 +8,7 @@ import {
   PlusCircleOutlined,
   SettingOutlined
 } from '@ant-design/icons';
-import {AccessControlService} from "../../../services/access.control.service";
+import {AccessControlService} from "../../../../services/access.control.service";
 import {Link, useLocation, useNavigate, useSearchParams} from "react-router-dom";
 import {SearchForm, SearchResult} from "../../../modules/search-form";
 

--- a/src/components/templates/login/DoorayLogin.js
+++ b/src/components/templates/login/DoorayLogin.js
@@ -1,9 +1,14 @@
 import React, {useState} from "react";
-import {Button, Form, Input, message, Modal} from "antd";
 import {LockOutlined, UserOutlined} from "@ant-design/icons";
-import {AuthService} from "../../auth/auth.service";
-import {EventBroadcaster, SHOW_ERROR_MESSAGE_EVENT_TOPIC} from "../../event/event.broadcaster";
-import {adminConfig} from "../../config/admin.config";
+import {AuthService} from "../../../auth/auth.service";
+import {EventBroadcaster, SHOW_ERROR_MESSAGE_EVENT_TOPIC} from "../../../event/event.broadcaster";
+import {adminConfig} from "../../../config/admin.config";
+import {SimpleModal} from "../../atoms/modal";
+import {Form} from "../../atoms/form";
+import {FormItem} from "../../atoms/form/form-item";
+import {TextInput} from "../../atoms/text-input";
+import {Button} from "../../atoms/button";
+import {message} from "antd";
 
 const DoorayLogin = ({show, onLoginSuccess, onClose}) => {
   const [loading, setLoading] = useState(false);
@@ -27,12 +32,11 @@ const DoorayLogin = ({show, onLoginSuccess, onClose}) => {
 
   return (
     <>
-      <Modal title={[<div key={1}><img src="/dooray-logo.svg" alt="dooray logo" width={100}/></div>]} open={show}
-             onCancel={onClose} footer={null} width={400}>
+      <SimpleModal title="두레이 로그인" footer={null} open={show} onCancel={onClose} width={400}>
         <Form
           onFinish={loginWithDooray}
         >
-          <Form.Item
+          <FormItem
             name="id"
             rules={[
               {
@@ -41,9 +45,9 @@ const DoorayLogin = ({show, onLoginSuccess, onClose}) => {
               },
             ]}
           >
-            <Input prefix={<UserOutlined className="site-form-item-icon"/>} placeholder="ID"/>
-          </Form.Item>
-          <Form.Item
+            <TextInput prefix={<UserOutlined className="site-form-item-icon"/>} placeholder="아이디"/>
+          </FormItem>
+          <FormItem
             name="password"
             rules={[
               {
@@ -52,19 +56,17 @@ const DoorayLogin = ({show, onLoginSuccess, onClose}) => {
               },
             ]}
           >
-            <Input
+            <TextInput
               prefix={<LockOutlined className="site-form-item-icon"/>}
               type="password"
-              placeholder="Password"
+              placeholder="비밀번호"
             />
-          </Form.Item>
-          <Form.Item>
-            <Button type="primary" htmlType="submit" className="login-form-button" loading={loading}>
-              Dooray Log in
-            </Button>
-          </Form.Item>
+          </FormItem>
+          <FormItem>
+            <Button label="로그인" type="primary" htmlType="submit" loading={loading}/>
+          </FormItem>
         </Form>
-      </Modal>
+      </SimpleModal>
     </>
   )
 }

--- a/src/components/templates/login/Login.js
+++ b/src/components/templates/login/Login.js
@@ -6,7 +6,7 @@ import {AuthService} from "../../../auth/auth.service";
 import {EventBroadcaster, SHOW_ERROR_MESSAGE_EVENT_TOPIC} from "../../../event/event.broadcaster";
 import {adminConfig} from "../../../config/admin.config";
 import {Title} from "../../atoms/typography/title";
-import DoorayLogin from "../../login/DoorayLogin";
+import DoorayLogin from "./DoorayLogin";
 import {TextInput} from "../../atoms/text-input";
 import {Button} from "../../atoms/button";
 import {Text} from "../../atoms/typography/text";
@@ -15,7 +15,7 @@ import {Image} from "../../atoms/image";
 import {Form} from "../../atoms/form";
 import {FormItem} from "../../atoms/form/form-item";
 import styled from "styled-components";
-import SiteService from "../../services/site.service";
+import SiteService from "../../../services/site.service";
 import MemberSignUp from "./MemberSignUp";
 
 const LoginWrapper = styled.div`

--- a/src/components/templates/login/MemberSignUp.js
+++ b/src/components/templates/login/MemberSignUp.js
@@ -1,15 +1,14 @@
 import React, {useState} from "react";
-import {message} from "antd";
+import {Form as AntForm, message} from "antd";
 import {FormOutlined, LockOutlined, UserOutlined} from "@ant-design/icons";
-import {MemberService} from "../../services/member.service";
+import {MemberService} from "../../../services/member.service";
 import {adminConfig} from "../../../config/admin.config";
 import {Form} from "../../atoms/form";
-import {Form as AntForm} from "antd";
 import {FormItem} from "../../atoms/form/form-item";
 import {TextInput} from "../../atoms/text-input";
 import {Button} from "../../atoms/button";
 import {EventBroadcaster, SHOW_ERROR_MESSAGE_EVENT_TOPIC} from "../../../event/event.broadcaster";
-import {Modal} from "../../atoms/modal";
+import {SimpleModal} from "../../atoms/modal";
 
 const MemberSignUp = ({show, onClose}) => {
   const [form] = AntForm.useForm()
@@ -42,7 +41,7 @@ const MemberSignUp = ({show, onClose}) => {
   }
 
   return (
-    <Modal title="계정 신청" open={show} onCancel={onClose} footer={null} width={400} onAfterClose={handleAfterClose}>
+    <SimpleModal title="계정 신청" open={show} onCancel={onClose} width={400} onAfterClose={handleAfterClose}>
       <Form
         form={form}
         onFinish={signUp}
@@ -106,7 +105,7 @@ const MemberSignUp = ({show, onClose}) => {
           <Button label="계정 신청" type="primary" htmlType="submit" loading={loading}/>
         </FormItem>
       </Form>
-    </Modal>
+    </SimpleModal>
   )
 }
 export default MemberSignUp;

--- a/src/components/templates/login/OAuthLoginResult.js
+++ b/src/components/templates/login/OAuthLoginResult.js
@@ -1,7 +1,7 @@
 import React from "react";
 import axios from "axios";
 import {Navigate, useLocation, useSearchParams} from "react-router-dom";
-import {adminConfig} from "../../config/admin.config";
+import {adminConfig} from "../../../config/admin.config";
 import {message} from "antd";
 
 const OAuthLoginResult = () => {

--- a/src/components/templates/member/MemberApproval.js
+++ b/src/components/templates/member/MemberApproval.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from "react";
 import {Button, Dropdown, message, Modal, PageHeader, Table} from 'antd';
-import {MemberService} from "../../services/member.service";
+import {MemberService} from "../../../services/member.service";
 import {
   CheckOutlined,
   CloseOutlined,

--- a/src/components/templates/member/MemberList.js
+++ b/src/components/templates/member/MemberList.js
@@ -3,7 +3,7 @@ import {Button, Col, Collapse, Dropdown, Form, Input, PageHeader, Row, Select, T
 import {DownOutlined, SettingOutlined} from "@ant-design/icons";
 import moment from "moment";
 import {useLocation, useNavigate, useSearchParams} from "react-router-dom";
-import {MemberService} from "../../services/member.service";
+import {MemberService} from "../../../services/member.service";
 import {SearchForm, SearchResult} from "../../modules/search-form";
 
 const {Panel} = Collapse;

--- a/src/components/templates/member/MemberRoleChange.js
+++ b/src/components/templates/member/MemberRoleChange.js
@@ -2,8 +2,8 @@ import React, {useEffect, useState} from "react";
 import {Button, Form, PageHeader, Select, message} from 'antd';
 import {useNavigate, useParams, useSearchParams} from "react-router-dom";
 import {FormItemLayout, FormTailItemLayout} from "../../modules/layout/from-item";
-import {AccessControlService} from "../../services/access.control.service";
-import {MemberService} from "../../services/member.service";
+import {AccessControlService} from "../../../services/access.control.service";
+import {MemberService} from "../../../services/member.service";
 
 const {Option} = Select;
 

--- a/src/components/templates/organization/OrganizationChangeMembers.js
+++ b/src/components/templates/organization/OrganizationChangeMembers.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from "react";
 import {Button, Descriptions, Form, message, PageHeader, Select} from 'antd';
-import {OrganizationService} from "../../services/organization.service";
-import {MemberService} from "../../services/member.service";
+import {OrganizationService} from "../../../services/organization.service";
+import {MemberService} from "../../../services/member.service";
 import {useNavigate, useParams, useSearchParams} from "react-router-dom";
 import {FormItemLayout, FormTailItemLayout} from "../../modules/layout/from-item";
 

--- a/src/components/templates/organization/OrganizationChangeRoles.js
+++ b/src/components/templates/organization/OrganizationChangeRoles.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from "react";
 import {Button, Descriptions, Form, message, PageHeader, Select} from 'antd';
-import {OrganizationService} from "../../services/organization.service";
-import {AccessControlService} from "../../services/access.control.service";
+import {OrganizationService} from "../../../services/organization.service";
+import {AccessControlService} from "../../../services/access.control.service";
 import {useNavigate, useParams, useSearchParams} from "react-router-dom";
 import {FormItemLayout, FormTailItemLayout} from "../../modules/layout/from-item";
 

--- a/src/components/templates/organization/OrganizationForm.js
+++ b/src/components/templates/organization/OrganizationForm.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from "react";
 import {Button, Form, Input, message, PageHeader} from 'antd';
-import {OrganizationService} from "../../services/organization.service";
+import {OrganizationService} from "../../../services/organization.service";
 import {useNavigate, useParams, useSearchParams} from "react-router-dom";
 import {FormItemLayout, FormTailItemLayout} from "../../modules/layout/from-item";
 

--- a/src/components/templates/organization/Organizations.js
+++ b/src/components/templates/organization/Organizations.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from "react";
 import {Button, Col, Descriptions, Dropdown, message, PageHeader, Popconfirm, Row, Tag, Tree} from "antd";
 import {ApartmentOutlined, DeleteOutlined, DownOutlined, EditOutlined, SettingOutlined} from "@ant-design/icons";
-import {OrganizationService} from "../../services/organization.service";
+import {OrganizationService} from "../../../services/organization.service";
 import {useLocation, useNavigate} from "react-router-dom";
 
 const Organizations = () => {

--- a/src/components/templates/settings/dooray/DoorayLoginSetting.js
+++ b/src/components/templates/settings/dooray/DoorayLoginSetting.js
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from "react";
 import {Button, Form, Input, message, PageHeader, Radio} from "antd";
 import {FormItemLayout, FormTailItemLayout} from "../../../modules/layout/from-item";
-import SiteService from "../../../services/site.service";
+import SiteService from "../../../../services/site.service";
 
 const SETTING_KEY = "dooray-login";
 

--- a/src/components/templates/settings/google/GoogleWorkspaceLoginSetting.js
+++ b/src/components/templates/settings/google/GoogleWorkspaceLoginSetting.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from "react";
 import {Button, Form, Input, message, PageHeader, Radio} from "antd";
-import SiteService from "../../../services/site.service";
+import SiteService from "../../../../services/site.service";
 import {FormItemLayout, FormTailItemLayout} from "../../../modules/layout/from-item";
 
 const SETTING_KEY = "google-workspace-login";

--- a/src/components/templates/webhook/notification-web-hooks/NotificationWebHookCallSampleDetails.js
+++ b/src/components/templates/webhook/notification-web-hooks/NotificationWebHookCallSampleDetails.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from "react";
 import {Descriptions, Divider, PageHeader} from 'antd';
-import {WebHookService} from "../../../services/webhook.service";
+import {WebHookService} from "../../../../services/webhook.service";
 import {useNavigate, useParams, useSearchParams} from "react-router-dom";
 
 const NotificationWebHookCallSampleDetails = () => {

--- a/src/components/templates/webhook/notification-web-hooks/NotificationWebHookForm.js
+++ b/src/components/templates/webhook/notification-web-hooks/NotificationWebHookForm.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from "react";
 import {Button, Form, Input, message, PageHeader} from 'antd';
-import {WebHookService} from "../../../services/webhook.service";
+import {WebHookService} from "../../../../services/webhook.service";
 import {useNavigate, useParams, useSearchParams} from "react-router-dom";
 import {FormItemLayout, FormTailItemLayout} from "../../../modules/layout/from-item";
 

--- a/src/components/templates/webhook/notification-web-hooks/NotificationWebHookList.js
+++ b/src/components/templates/webhook/notification-web-hooks/NotificationWebHookList.js
@@ -8,7 +8,7 @@ import {
   PlusCircleOutlined,
   SettingOutlined
 } from "@ant-design/icons";
-import {WebHookService} from "../../../services/webhook.service";
+import {WebHookService} from "../../../../services/webhook.service";
 import {useLocation, useNavigate, useSearchParams} from "react-router-dom";
 import {CgDetailsMore} from "react-icons/cg";
 

--- a/src/services/access.control.service.js
+++ b/src/services/access.control.service.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import {adminConfig} from "../../config/admin.config";
+import {adminConfig} from "../config/admin.config";
 
 const API_URL = adminConfig.authentication.authAPI();
 

--- a/src/services/member.service.js
+++ b/src/services/member.service.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import {adminConfig} from "../../config/admin.config";
+import {adminConfig} from "../config/admin.config";
 
 const API_URL = adminConfig.authentication.authAPI();
 

--- a/src/services/organization.service.js
+++ b/src/services/organization.service.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import {adminConfig} from "../../config/admin.config";
+import {adminConfig} from "../config/admin.config";
 
 const API_URL = adminConfig.authentication.authAPI();
 

--- a/src/services/site.service.js
+++ b/src/services/site.service.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import {adminConfig} from "../../config/admin.config";
+import {adminConfig} from "../config/admin.config";
 
 const API_URL = adminConfig.authentication.authAPI();
 

--- a/src/services/webhook.service.js
+++ b/src/services/webhook.service.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import {adminConfig} from "../../config/admin.config";
+import {adminConfig} from "../config/admin.config";
 
 const API_URL = adminConfig.authentication.authAPI();
 


### PR DESCRIPTION
#216 

아래와 같이 대체
![image](https://user-images.githubusercontent.com/16472109/207240074-7e1bbedf-0a27-4ef5-a196-ab258b612441.png)


@torouso 아래와 같이 Modal 컴포넌트를 2개로 나누었습니다.

![image](https://user-images.githubusercontent.com/16472109/207240135-a0a36ba1-9162-44b7-8b29-9caf38bcac44.png)

![image](https://user-images.githubusercontent.com/16472109/207240157-5bcf4fa9-b71c-4a9c-a605-82761c86a705.png)
